### PR TITLE
Reinstall modern postgresql packages after the conversion.

### DIFF
--- a/common/leapp_configs.py
+++ b/common/leapp_configs.py
@@ -42,6 +42,7 @@ def _do_name_replacement(name):
     return _do_replacement(name, [
         lambda to_change: "Alma " + to_change,
         lambda to_change: to_change.replace("Enterprise Linux 7",  "Enterprise Linux 8"),
+        lambda to_change: to_change.replace("$releasever", "8"),
     ])
 
 
@@ -63,12 +64,16 @@ def _do_url_replacement(url):
         lambda to_change: to_change.replace("epel-source-7", "epel-source-8"),
         lambda to_change: to_change.replace("centos7", "centos8"),
         lambda to_change: to_change.replace("centos/7", "centos/8"),
+        lambda to_change: to_change.replace("rhel-$releasever", "rhel-8"),
     ])
 
 
 def _do_common_replacement(line):
     return _do_replacement(line, [
         lambda to_change: to_change.replace("EPEL-7", "EPEL-8"),
+        # We can't check repository gpg because the key is not stored in the temporary file system
+        # ToDo: Maybe we could find a way to put the key into the file system
+        lambda to_change: to_change.replace("repo_gpgcheck = 1", "repo_gpgcheck = 0"),
     ])
 
 

--- a/main.py
+++ b/main.py
@@ -70,6 +70,7 @@ def construct_actions(options, stage_flag):
                 actions.AddUpgradeSystemdService(os.path.abspath(sys.argv[0])),
                 actions.LeapReposConfiguration(),
                 actions.AvoidMariadbDowngrade(),
+                actions.PostgresReinstallModernPackage(),
                 actions.LeapChoicesConfiguration(),
                 actions.FixNamedConfig(),
             ],


### PR DESCRIPTION
The leapp cannot update the modern postgresql packages installed from the official postgresql repository properly. It looks like this is happening because it tries to replace them with standard AlmaLinux postgresql packages and fails. So we have to reinstall these packages by ourselves.