### PR TITLE
Check if the last installed kernel version is currently in use

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,7 @@ def is_required_conditions_satisfied(options, stage_flag):
             actions.CheckGrubInstalled(),
             actions.CheckNoMoreThenOneKernelNamedNIC(),
             actions.CheckIsInContainer(),
+            actions.CheckLastInstalledKernelInUse(),
         ]
         if not options.upgrade_postgres_allowed:
             checks.append(actions.CheckOutdatedPostgresInstalled())


### PR DESCRIPTION
Leapp performs this check on its side, so to avoid all of the preparations before leapp fails anyway, we should also make the check.