### PR TITLE
Ensure that there are no duplicate repositories by adding a check act…

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,7 @@ def is_required_conditions_satisfied(options, stage_flag):
             actions.CheckIsInContainer(),
             actions.CheckLastInstalledKernelInUse(),
             actions.CheckIsLocalRepositoryNotPresent(),
+            actions.CheckRepositoryDuplicates(),
         ]
         if not options.upgrade_postgres_allowed:
             checks.append(actions.CheckOutdatedPostgresInstalled())


### PR DESCRIPTION
…ion before the conversion process

Leapp does not support repositories with duplicates, so we need to verify that there are none before proceeding with the conversion.