### PR TITLE
Introduce a 45-second delay before the initial reboot

### DIFF
--- a/actions/common.py
+++ b/actions/common.py
@@ -4,9 +4,10 @@ from .action import ActiveAction
 import os
 import subprocess
 import sys
+import time
 
 import common
-from common import motd, util, rpm
+from common import messages, motd, util, rpm
 
 
 class FixNamedConfig(ActiveAction):
@@ -165,3 +166,20 @@ class DisablePleskSshBanner(ActiveAction):
 
     def _revert_action(self):
         common.restore_file_from_backup(self.banner_command_path)
+
+
+class PreRebootPause(ActiveAction):
+    def __init__(self):
+        self.name = "pause before reboot"
+        self.pause_time = 45
+        self.message = messages.REBOOT_WARN_MESSAGE.format(delay=self.pause_time)
+
+    def _prepare_action(self):
+        print(self.message)
+        time.sleep(self.pause_time)
+
+    def _post_action(self):
+        pass
+
+    def _revert_action(self):
+        pass

--- a/common/messages.py
+++ b/common/messages.py
@@ -53,3 +53,10 @@ For further assistance, create an issue in our GitHub repository - https://githu
 Please attach the feedback archive to the created issue and provide as much information about the problem as you can.
 **************************************************************************************\033[0m
 """
+
+REBOOT_WARN_MESSAGE = """\r\033[93m****************************** WARNING ***********************************************
+\033[92mThe conversion is ready to begin. The server will be rebooted in {delay} seconds.
+The conversion process will take approximately 25 minutes. If you wish to prevent the reboot, simply
+terminate the centos2alma process. Please note that Plesk functionality is currently unavailable.
+\033[93m**************************************************************************************\033[0m
+"""

--- a/main.py
+++ b/main.py
@@ -188,6 +188,9 @@ def construct_actions(options, stage_flag):
         4: [
             actions.DoConvert(),
         ],
+        5: [
+            actions.PreRebootPause(),
+        ]
     })
 
     if options.upgrade_postgres_allowed:


### PR DESCRIPTION
Related issue #89 ([comment](https://github.com/plesk/centos2alma/issues/89#issuecomment-1534819859))