### PR TITLE
Migrate to Docker-based Buck build to ensure Buck installation is fine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,21 +8,14 @@ jobs:
                           # https://github.com/actions/setup-python/issues/544
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - name: Prepare artifact store
+      run: mkdir -p ./buck-out/gen
+    - name: Build centos2alma
+      id: build
+      uses: SandakovMM/build-with-buck@v1
       with:
-        java-version: 8
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.6
-    - name: Install buck from official github (release 2022.05.05.01)
-      run: >
-          wget https://github.com/facebook/buck/releases/download/v2022.05.05.01/buck.2022.05.05.01_all.deb -O buck.deb
-          && sudo apt-get install openjdk-8-jre-headless
-          && sudo dpkg --install buck.deb
-    - name: Build our program
-      run: buck build :centos2alma
-    - name: Prepare result
-      run: mv buck-out/gen/centos2alma.pex buck-out/gen/centos2alma
+        command: build
+        target: :centos2alma
     - name: Store result
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,9 @@ jobs:
                           # https://github.com/actions/setup-python/issues/544
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.6
-    - name: Install buck from official github (release 2022.05.05.01)
-      run: >
-          wget https://github.com/facebook/buck/releases/download/v2022.05.05.01/buck.2022.05.05.01_all.deb -O buck.deb
-          && sudo apt-get install openjdk-8-jre-headless
-          && sudo dpkg --install buck.deb
     - name: Perform tests
-      run: buck test :libs.tests
+      id: test
+      uses: SandakovMM/build-with-buck@v1
+      with:
+        command: test
+        target: :libs.tests

--- a/BUCK
+++ b/BUCK
@@ -42,10 +42,17 @@ python_test(
 )
 
 python_binary(
-    name = 'centos2alma',
+    name = 'centos2alma-script',
     platform = 'py3',
     main_module = 'main',
     deps = [
         ':libs.lib',
     ]
+)
+
+genrule(
+    name = 'centos2alma',
+    srcs = [':centos2alma-script'],
+    out = 'centos2alma',
+    cmd = 'cp $(location :centos2alma-script) $OUT && chmod +x $OUT',
 )

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,28 @@
+# The Dockerfile was brought from the repository build-with-buck
+# https://github.com/SandakovMM/build-with-buck
+# But little changed. Because GitHub actions mount sourcecode inside
+# the action, but we should do the same inside the container manually.
+# So to build you shoud just call docker like this:
+# > docker run -v ./:/target [container-name] build :centos2alma
+FROM openjdk:8
+
+MAINTAINER mmsandakov@gmail.com
+
+# Prepare environment
+RUN apt-get update && apt-get install -y git ant build-essential gcc python python-dev python3-distutils
+RUN useradd -m -s /bin/false buck
+RUN mkdir /buck && chown buck /buck
+USER buck
+
+# Build buck
+# We could just clone because I don't expect buck to be updated in this repository
+# ToDo: move to buck2
+RUN git clone https://github.com/facebook/buck.git /buck/
+RUN cd /buck && ant
+
+# We shoul return to root because github actions expects it
+USER root
+RUN ln -sf /buck/bin/buck /usr/bin/ ; mkdir /target
+WORKDIR /target
+
+ENTRYPOINT ["/usr/bin/buck"]

--- a/tests/rpmtests.py
+++ b/tests/rpmtests.py
@@ -231,11 +231,17 @@ gpgcheck=0
 
 
 class HandleRpmnewFilesTests(unittest.TestCase):
+    def tearDown(self):
+        tests_related_files = ["test.txt", "test.txt.rpmnew", "test.txt.rpmsave"]
+        for file in tests_related_files:
+            if os.path.exists(file):
+                os.remove(file)
+
     def test_no_rpmnew(self):
         with open("test.txt", "w") as f:
             f.write("test")
 
-        self.assertFalse(rpm.handle_rpmnew_files("test.txt"))
+        self.assertFalse(rpm.handle_rpmnew("test.txt"))
 
     def test_has_rpmnew(self):
         with open("test.txt", "w") as f:
@@ -244,18 +250,18 @@ class HandleRpmnewFilesTests(unittest.TestCase):
         with open("test.txt.rpmnew", "w") as f:
             f.write("2")
 
-        self.assertTrue(rpm.handle_rpmnew_files("test.txt"))
+        self.assertTrue(rpm.handle_rpmnew("test.txt"))
         self.assertTrue(os.path.exists("test.txt"))
         self.assertEqual(open("test.txt").read(), "2")
 
         self.assertTrue(os.path.exists("test.txt.rpmsave"))
-        self.assertEqual(open("test.txt.rpmnew").read(), "1")
+        self.assertEqual(open("test.txt.rpmsave").read(), "1")
 
     def test_missing_original(self):
         with open("test.txt.rpmnew", "w") as f:
             f.write("2")
 
-        self.assertTrue(rpm.handle_rpmnew_files("test.txt"))
+        self.assertTrue(rpm.handle_rpmnew("test.txt"))
         self.assertTrue(os.path.exists("test.txt"))
         self.assertEqual(open("test.txt").read(), "2")
 


### PR DESCRIPTION
Encountered issues with OpenJDK installation on Azure instances. It appears that some packages are missing on their side. Since I was planned to provide Dockerfile for build anyway, let's move to docker based build on actions as well.