### PR TITLE
Replace the logrotate configuration for syslog with a similar configuration for rsyslog after the conversion

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,6 +215,7 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
             ],
             2: [
                 actions.RebundleRubyApplications(),
+                actions.FixSyslogLogrotateConfig(),
             ],
             4: [
                 actions.AdoptRepositories(),


### PR DESCRIPTION
Due to AlmaLinux 8 using rsyslog instead of syslog, we cannot utilize the syslog logrotate configuration. Unfortunately, Elevate is unable to replace the configuration during the conversion process itself. Therefore, we need to manually make the necessary changes.