### PR TITLE
Make sure we use python 3.6 on build

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -3,4 +3,4 @@
 [python]
     interpreter = python2.7
 [python#py3]
-    interpreter = python3
+    interpreter = /usr/bin/python3.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       run: mkdir -p ./buck-out/gen
     - name: Build centos2alma
       id: build
-      uses: SandakovMM/build-with-buck@v1
+      uses: SandakovMM/build-with-buck@v2
       with:
         command: build
         target: :centos2alma

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Perform tests
       id: test
-      uses: SandakovMM/build-with-buck@v1
+      uses: SandakovMM/build-with-buck@v2
       with:
         command: test
         target: :libs.tests


### PR DESCRIPTION
Plesk brings exactly this version of python, so we need to make sure we build against right version. Othervise the tool just can't be started on an instance with Plesk