### PR TITLE
Workaround to prevent the elevate isscf parser from crashing by adding specific comments

### DIFF
--- a/actions/common.py
+++ b/actions/common.py
@@ -24,9 +24,19 @@ class FixNamedConfig(ActiveAction):
         if not os.path.exists(self.user_options_path):
             os.symlink(self.chrooted_file_path, self.user_options_path)
 
+        if os.path.getsize(self.chrooted_file_path) == 0:
+            with open(self.chrooted_file_path, "w") as f:
+                f.write("# centos2alma workaround commentary")
+
     def _post_action(self) -> None:
         if os.path.exists(self.user_options_path):
             os.unlink(self.user_options_path)
+
+        with open(self.chrooted_file_path, "r") as f:
+            if f.read() == "# centos2alma workaround commentary":
+                os.unlink(self.chrooted_file_path)
+                with open(self.chrooted_file_path, "w") as _:
+                    pass
 
     def _revert_action(self) -> None:
         if os.path.exists(self.user_options_path):


### PR DESCRIPTION
The elevate isscf configuration parser would crash if the named config includes an empty file. This issue likely occurs because it first attempts to get a character from the string by index before checking if the index is lower than end_index. As a solution, we added any commentary string into the included named configuration. Another option would be to patch the elevate source code, but maintaining the patch can be complex, so we opted for the workaround until it is fixed on the elevate side.