### PR TITLE
Move MariaDB to the rhel8 repository instead of centos8 during conversion

### DIFF
--- a/common/leapp_configs.py
+++ b/common/leapp_configs.py
@@ -67,10 +67,20 @@ def _fix_rackspace_repository(to_change: str) -> str:
     return to_change
 
 
+def _fix_mariadb_repository(to_change: str) -> str:
+    # Mariadb official repository doesn't support short url for centos 8 since 10.11
+    # Since there are short URL for rhel8 short for all versions, we could use it instead
+    if "yum.mariadb.org" in to_change:
+        return to_change.replace("centos7", "rhel8")
+
+    return to_change
+
+
 def _do_url_replacement(url: str) -> str:
     return _do_replacement(url, [
         _fixup_old_php_urls,
         _fix_rackspace_repository,
+        _fix_mariadb_repository,
         lambda to_change: to_change.replace("rpm-CentOS-7", "rpm-RedHat-el8"),
         lambda to_change: to_change.replace("epel-7", "epel-8"),
         lambda to_change: to_change.replace("epel-debug-7", "epel-debug-8"),

--- a/tests/leapp_configs_tests.py
+++ b/tests/leapp_configs_tests.py
@@ -207,6 +207,29 @@ PLESK_18_0_XX-PHP80,alma-PLESK_18_0_XX-PHP80,alma-PLESK_18_0_XX-PHP80,all,all,x8
                            expected_leapp_repos, expected_leapp_mapping,
                            ignore=["PLESK_18_0_XX-PHP-5.5"])
 
+    def test_mariadb_mapping(self):
+        mariadb_like_repos = """[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.11/centos7-amd64
+module_hotfixes=1
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+"""
+
+        expected_mariadb_repos = """[alma-mariadb]
+name=Alma MariaDB
+baseurl=http://yum.mariadb.org/10.11/rhel8-amd64
+module_hotfixes=1
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+"""
+
+        expected_mariadb_mapping = """mariadb,alma-mariadb,alma-mariadb,all,all,x86_64,rpm,ga,ga
+"""
+
+        self._perform_test({"mariadb.repo": mariadb_like_repos},
+                           expected_mariadb_repos, expected_mariadb_mapping)
+
 
 class SetPackageRepositoryTests(unittest.TestCase):
     INITIAL_JSON = {


### PR DESCRIPTION
There is not centos8-* repositories since MariaDB 10.11. Therefore, we need to switch to either RHEL8 or "centos/8/*". While there isn't much difference between them,
moving to RHEL8 seems simpler, so I decided to use it.