### PR TITLE
Support kernel-plus, kernel-rt and other specific kernels

### DIFF
--- a/actions/common_checks.py
+++ b/actions/common_checks.py
@@ -299,23 +299,12 @@ class CheckLastInstalledKernelInUse(action.CheckAction):
 
     def _get_last_installed_kernel_version(self) -> version.KernelVersion:
         versions = subprocess.check_output(["/usr/bin/rpm", "-q", "-a", "kernel"], universal_newlines=True).splitlines()
-        # There is 'kernel-' prefix, that doesn't matter for us now, so just skip it
-        versions = [ver.split("-", 1)[-1] for ver in versions]
 
         log.debug("Installed kernel versions: {}".format(', '.join(versions)))
-
         versions = [version.KernelVersion(ver) for ver in versions]
         return max(versions)
 
-    def _is_realtime_installed(self) -> bool:
-        return len(subprocess.check_output(["/usr/bin/rpm", "-q", "-a", "kernel-rt"], universal_newlines=True).splitlines()) > 0
-
     def _do_check(self) -> bool:
-        # For now skip checking realtime kernels. leapp will check it on it's side
-        # I believe we have no much installation with realtime kernel
-        if self._is_realtime_installed():
-            return True
-
         last_installed_kernel_version = self._get_last_installed_kernel_version()
         used_kernel_version = self._get_kernel_version_in_use()
 


### PR DESCRIPTION
Since KernelVersion now could parce versions with any prefixes like "kernel-", "kernel-rt-", "kernel-plus-", we can just pass row names of rpm packages.