### PR TITLE
Patch the leapp package signature checker to prevent errors when writing non-ASCII string into logs

### DIFF
--- a/actions/configure.py
+++ b/actions/configure.py
@@ -86,3 +86,24 @@ class PatchLeappErrorOutput(action.ActiveAction):
 
     def _revert_action(self) -> None:
         pass
+
+
+class PatchLeappDebugNonAsciiPackager(action.ActiveAction):
+
+    def __init__(self):
+        self.name = "patch leapp to allow print debug message for non-ascii packager"
+        self.path_to_src = "/usr/share/leapp-repository/repositories/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py"
+
+    def is_required(self) -> bool:
+        return os.path.exists(self.path_to_src)
+
+    def _prepare_action(self) -> None:
+        # so sometimes we could have non-ascii packager name, in this case leapp will fail
+        # on printing debug message. So we need to encode it to utf-8 before print (and only before print I think)
+        files.replace_string(self.path_to_src, ", pkg.packager", ", pkg.packager.encode('utf-8')")
+
+    def _post_action(self) -> None:
+        pass
+
+    def _revert_action(self) -> None:
+        pass

--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
             actions.AdoptKolabRepositories(),
             actions.FixupImunify(),
             actions.PatchLeappErrorOutput(),
+            actions.PatchLeappDebugNonAsciiPackager(),
             actions.AddUpgradeSystemdService(os.path.abspath(sys.argv[0]), options),
             actions.UpdatePlesk(),
             actions.PostgresReinstallModernPackage(),


### PR DESCRIPTION
Related issue is #171 