### PR TITLE
Increase size of DH parameters to at least 2048 bit for dovecot

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -3,6 +3,7 @@ from .common_checks import *
 from .common import *
 from .configure import *
 from .convert import *
+from .emails import *
 from .extensions import *
 from .installation import *
 from .mariadb import *

--- a/actions/emails.py
+++ b/actions/emails.py
@@ -1,0 +1,51 @@
+# Copyright 1999 - 2023. Plesk International GmbH. All rights reserved.
+import json
+import subprocess
+
+from common import action, log, util
+
+
+class IncreaseDovecotDHParameters(action.ActiveAction):
+    def __init__(self):
+        self.name = "increase Dovecot DH parameters size to 2048 bits"
+        self.dhparam_size = 2048
+
+    def _is_required(self) -> bool:
+        proc = subprocess.run(
+            ["/usr/sbin/plesk", "sbin", "sslmng", "--show-config"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        if proc.returncode != 0:
+            log.warn(f"Failed to get ssl configuration by plesk sslmng: {proc.stdout}\n{proc.stderr}")
+            return False
+
+        try:
+            sslmng_config = json.loads(proc.stdout)
+            if int(sslmng_config["effective"]["dovecot"]["dhparams_size"]) >= self.dhparam_size:
+                return False
+        except json.JSONDecodeError:
+            log.warn(f"Failed to parse plesk sslmng results: {proc.stdout}")
+            return False
+
+        return True
+
+    def _prepare_action(self) -> None:
+        pass
+
+    def _post_action(self) -> None:
+        util.logged_check_call(
+            [
+                "/usr/sbin/plesk", "sbin", "sslmng",
+                "--service", "dovecot",
+                "--strong-dh",
+                f"--dhparams-size={self.dhparam_size}",
+            ]
+        )
+
+    def _revert_action(self) -> None:
+        pass
+
+    def estimate_post_time(self) -> int:
+        return 5

--- a/main.py
+++ b/main.py
@@ -196,6 +196,7 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
             actions.PostgresReinstallModernPackage(),
             actions.FixNamedConfig(),
             actions.RecreateAwstatConfigurationFiles(),
+            actions.IncreaseDovecotDHParameters(),
         ],
         3: [
             actions.DisablePleskSshBanner(),


### PR DESCRIPTION
Since we moves to roundcube 1.6 after the conversion, we have to increase size of DH parameters. Othervise it seems like roundcube refuses the connection.