### PR TITLE
Restore the dovecot configuration after the conversion is complete

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,6 +199,7 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
             actions.UpdatePlesk(),
             actions.PostgresReinstallModernPackage(),
             actions.FixNamedConfig(),
+            actions.RestoreDovecotConfiguration(),
             actions.RecreateAwstatConfigurationFiles(),
             actions.IncreaseDovecotDHParameters(),
             actions.FixOsVendorPhpFpmConfiguration(),


### PR DESCRIPTION
We need to restore it because customers often modify the configuration to disable digest-md5 and avoid authentication issues in webmail