### PR TITLE
Skip RecreateAwstatConfigurationFiles if there is no required file for awstat configuration creation

### DIFF
--- a/centos2almaconverter/actions/common.py
+++ b/centos2almaconverter/actions/common.py
@@ -135,6 +135,9 @@ class RecreateAwstatConfigurationFiles(action.ActiveAction):
     def __init__(self):
         self.name = "recreate awstat configuration files for domains"
 
+    def _is_required(self) -> bool:
+        return os.path.exists("/etc/awstats/awstats.model.conf")
+
     def get_awstat_domains(self) -> typing.Set[str]:
         domains_awstats_directory = "/usr/local/psa/etc/awstats/"
         domains = set()


### PR DESCRIPTION
This likely indicates that awstats was removed

Related issue is #267 