### PR TITLE
Add a feature to block conversion if the repository's source is an IP address

### DIFF
--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -212,6 +212,7 @@ class Centos2AlmaConverter(DistUpgrader):
             centos2alma_actions.AssertRedHatKernelInstalled(),
             centos2alma_actions.AssertLastInstalledKernelInUse(),
             centos2alma_actions.AssertLocalRepositoryNotPresent(),
+            centos2alma_actions.AssertIPRepositoryNotPresent(),
             centos2alma_actions.AssertThereIsNoRepositoryDuplicates(),
             centos2alma_actions.AssertMariadbRepoAvailable(),
             common_actions.AssertNotInContainer(),


### PR DESCRIPTION
Certain repositories (like custom ELS for Centos 7) can cause failures in dnf on AlmaLinux 8. Therefore, we need to stop conversion in these cases