### PR TITLE
Prevent leapp issues by removing libidn2 and lua-socket prior to conversion

### DIFF
--- a/centos2almaconverter/actions/packages.py
+++ b/centos2almaconverter/actions/packages.py
@@ -117,6 +117,8 @@ class ReinstallConflictPackages(action.ActiveAction):
             "libwebp7": "libwebp",
             "libzip5": "libzip",
             "libytnef": "ytnef",
+            "libidn2": "libidn2",
+            "lua-socket": "lua-socket",
         }
 
     def _is_required(self):


### PR DESCRIPTION
Address potential conflicts caused by the prohibition of package downgrades in dnf. This is due to the higher package versions present in CentOS 7 compared to AlmaLinux 8, which could disrupt the conversion process.