### PR TITLE
Use GRUB2 installed pre-checker instead of checking for any GRUB installation

### DIFF
--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -213,7 +213,7 @@ class Centos2AlmaConverter(DistUpgrader):
             common_actions.AssertMinPhpVersionUsedByWebsites(FIRST_SUPPORTED_BY_ALMA_8_PHP_VERSION),
             common_actions.AssertMinPhpVersionUsedByCron(FIRST_SUPPORTED_BY_ALMA_8_PHP_VERSION),
             common_actions.AssertOsVendorPhpUsedByWebsites(FIRST_SUPPORTED_BY_ALMA_8_PHP_VERSION),
-            common_actions.AssertGrubInstalled(),
+            common_actions.AssertGrub2Installed(),
             centos2alma_actions.AssertNoMoreThenOneKernelNamedNIC(),
             centos2alma_actions.AssertRedHatKernelInstalled(),
             centos2alma_actions.AssertLastInstalledKernelInUse(),


### PR DESCRIPTION
Leapp specifically requires GRUB2 for correct operation; otherwise, it will block the conversion