### PR TITLE
Added an assertion to ensure only one kernel-devel package is installed

### DIFF
--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -227,6 +227,7 @@ class Centos2AlmaConverter(DistUpgrader):
             centos2alma_actions.CheckOutdatedLetsencryptExtensionRepository(),
             centos2alma_actions.AssertPleskRepositoriesNotNoneLink(),
             centos2alma_actions.AssertNoAbsoluteLinksInRoot(),
+            common_actions.AssertNoMoreThenOneKernelDevelInstalled(),
             # LiteSpeed is not supported yet
             common_actions.AssertPleskExtensions(not_installed=["litespeed"])
         ]


### PR DESCRIPTION
Leapp cannot handle conversion if multiple kernel-devel packages are present, so we need to verify this on our end