### PR TITLE
Verify if PermitRootLogin is configured for sshd before initiating the conversion

### DIFF
--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -229,6 +229,7 @@ class Centos2AlmaConverter(DistUpgrader):
             centos2alma_actions.AssertNoAbsoluteLinksInRoot(),
             common_actions.AssertNoMoreThenOneKernelDevelInstalled(),
             common_actions.AssertEnoughRamForAmavis(ALMALINUX8_AMAVIS_REQUIRED_RAM, self.amavis_upgrade_allowed),
+            common_actions.AssertSshPermitRootLoginConfigured(),
             # LiteSpeed is not supported yet
             common_actions.AssertPleskExtensions(not_installed=["litespeed"])
         ]


### PR DESCRIPTION
This pre-check was inspired by the Leapp pre-checker, which prevents issues during conversion. The default setting was changed in AlmaLinux 8,
so we need this pre-check to avoid potential connection problems.

Related issues is #332 