### PR TITLE
Update the dist-upgrader submodule, switch to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dist-upgrader"]
 	path = dist-upgrader
-	url = git@github.com:plesk/dist-upgrader.git
+	url = https://github.com/plesk/dist-upgrader.git


### PR DESCRIPTION
Bring in recent changes from dist-upgrader.

Also, switch its URL to HTTPS. It's more convenient, because it doesn't require an SSH key.