### PR TITLE
FIX add checking .autoinstallerrc for archive SOURCE

### DIFF
--- a/centos2almaconverter/actions/packages.py
+++ b/centos2almaconverter/actions/packages.py
@@ -2,6 +2,7 @@
 import os
 import typing
 import shutil
+import re
 
 from pleskdistup.common import action, files, leapp_configs, log, motd, packages, rpm, systemd, util
 from pleskdistup.upgrader import PathType
@@ -435,3 +436,24 @@ class AdoptAtomicRepositories(action.ActiveAction):
 
     def _revert_action(self) -> action.ActionResult:
         return action.ActionResult()
+
+
+class CheckSourcePointsToArchiveURL(action.CheckAction):
+    AUTOINSTALLERRC_PATH = os.path.expanduser('~/.autoinstallerrc')
+
+    def __init__(self):
+        self.name = "checking if SOURCE points to old archive"
+        self.description = """Old archive doesn't serve up-to-date Plesk.
+\tEdit {self.AUTOINSTALLERRC_PATH} and change SOURCE - i.e. https://autoinstall.plesk.com
+"""
+
+    def _do_check(self) -> bool:
+        if not os.path.exists(self.AUTOINSTALLERRC_PATH):
+            return True
+        p = re.compile('^\s*SOURCE\s*=\s*https?://autoinstall-archives.plesk.com')
+        with open(self.AUTOINSTALLERRC_PATH) as f:
+            for line in f:
+                if p.search(line):
+                    return False
+        return True
+

--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -228,6 +228,7 @@ class Centos2AlmaConverter(DistUpgrader):
             centos2alma_actions.CheckOutdatedLetsencryptExtensionRepository(),
             centos2alma_actions.AssertPleskRepositoriesNotNoneLink(),
             centos2alma_actions.AssertNoAbsoluteLinksInRoot(),
+            centos2alma_actions.CheckSourcePointsToArchiveURL(),
             common_actions.AssertNoMoreThenOneKernelDevelInstalled(),
             common_actions.AssertEnoughRamForAmavis(ALMALINUX8_AMAVIS_REQUIRED_RAM, self.amavis_upgrade_allowed),
             common_actions.AssertSshPermitRootLoginConfigured(),


### PR DESCRIPTION
Fixes PAUX-6347: centos2alma fails when plesk was originally installed from archive