### PR TITLE
Fix message when autoinstallerrc has Plesk archive SOURCE

### DIFF
--- a/centos2almaconverter/actions/packages.py
+++ b/centos2almaconverter/actions/packages.py
@@ -443,9 +443,9 @@ class CheckSourcePointsToArchiveURL(action.CheckAction):
 
     def __init__(self):
         self.name = "checking if SOURCE points to old archive"
-        self.description = """Old archive doesn't serve up-to-date Plesk.
+        self.description = f"""Old archive doesn't serve up-to-date Plesk.
 \tEdit {self.AUTOINSTALLERRC_PATH} and change SOURCE - i.e. https://autoinstall.plesk.com
-"""
+""".format(self)
 
     def _do_check(self) -> bool:
         if not os.path.exists(self.AUTOINSTALLERRC_PATH):


### PR DESCRIPTION
Old message was like:
```
[root@ip-10-69-45-162 ~]# ./centos2alma 
Doing preparation checks...
Required pre-conversion condition 'checking if all packages are up to date' not met:
	There are packages which are not up to date. Call `yum update -y && reboot` to update the packages.

Required pre-conversion condition 'checking if SOURCE points to old archive' not met:
	Old archive doesn't serve up-to-date Plesk.
	Edit {self.AUTOINSTALLERRC_PATH} and change SOURCE - i.e. https://autoinstall.plesk.com

Conversion can't be performed due to the problems noted above
