### PR TITLE
Don't remove libidn2 prior to conversion.

### DIFF
--- a/centos2almaconverter/actions/packages.py
+++ b/centos2almaconverter/actions/packages.py
@@ -119,7 +119,6 @@ class ReinstallConflictPackages(action.ActiveAction):
             "libwebp7": "libwebp",
             "libzip5": "libzip",
             "libytnef": "ytnef",
-            "libidn2": "libidn2",
             "lua-socket": "lua-socket",
         }
 


### PR DESCRIPTION
Even though CentOS 7 has libidn2-2.3.7-1.el7.x86_64, which is higher than AlmaLinux 8 version libidn2-2.2.0-1.el8.x86_64, it is correctly downgraded on conversion.

Note that missing libidn2 might cause issues with dnf operation in case upgraded libcurl is used.

Removal was originally added in 78ff7d93692a5ef2fc305fb75de8395af294faa6.