### PR TITLE
Point to --resume when the process fails after reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ See the /var/log/plesk/centos2alma.log file for more information.
 You can remove this message from the /etc/motd file.
 ===============================================================================
 ```
-You can read the centos2alma log to troubleshoot the issue. If the centos2alma finish stage fails for any reason, once you have resolved the root cause of the failure, you can retry by running 'centos2alma -s finish'.
+You can read the centos2alma log to troubleshoot the issue. If the centos2alma finish stage fails for any reason, once you have resolved the root cause of the failure, you can retry by running:
+
+```shell
+> ./centos2alma --resume
+```
 
 ### Send feedback
 If you got any error, please [create an issue on github](https://github.com/plesk/centos2alma/issues). To do generate feedback archive by calling the tool with '-f' or '--prepare-feedback' flags.


### PR DESCRIPTION
I found out that the `-s finish` flag does not work when the process fails after the first reboot.
Instead the `--resume` flag should work.