### PR TITLE
Fetch Imunify360 extension GPG key for Leapp configurations

### DIFF
--- a/centos2almaconverter/actions/extensions.py
+++ b/centos2almaconverter/actions/extensions.py
@@ -92,3 +92,10 @@ class FetchPleskGPGKey(common_actions.FetchGPGKeyForLeapp):
         self.name = "fetching Plesk GPG key"
         self.target_repository_files_regex = ["plesk*.repo"]
         super().__init__()
+
+
+class FetchImunifyGPGKey(common_actions.FetchGPGKeyForLeapp):
+    def __init__(self):
+        self.name = "fetching Imunify360 GPG key"
+        self.target_repository_files_regex = ["imunify*.repo"]
+        super().__init__()

--- a/centos2almaconverter/upgrader.py
+++ b/centos2almaconverter/upgrader.py
@@ -135,6 +135,7 @@ class Centos2AlmaConverter(DistUpgrader):
                 centos2alma_actions.RemoveOldMigratorThirparty(),
                 centos2alma_actions.FetchKernelCareGPGKey(),
                 centos2alma_actions.FetchPleskGPGKey(),
+                centos2alma_actions.FetchImunifyGPGKey(),
                 centos2alma_actions.LeapReposConfiguration(),
                 centos2alma_actions.LeapChoicesConfiguration(),
                 centos2alma_actions.AdoptKolabRepositories(),


### PR DESCRIPTION
Leapp needs to verify GPG keys for mapping repositories. To support this, we now download the CloudLinux GPG key used by the Imunify extensions and inject it into Leapp configurations.